### PR TITLE
Issue1873: delete text inside <del> tags in entry titles

### DIFF
--- a/recipe.py
+++ b/recipe.py
@@ -51,7 +51,7 @@ class Recipe:
             return categories[0].split('"')[1].split(';')
         return []
 
-    def find_title(self, text: str) -> str:
+    def find_title(self, text: str, remove_del_text=False) -> str:
         """ 
         Use a regex to find text in between head tags. Specifying the version is not necessary since it is
         included in the dict comprehension statement where this function is called.
@@ -65,7 +65,10 @@ class Recipe:
         text = re.sub(r'\s+', ' ', text.replace('\n', ' '))
 
         titles = re_head.search(text)
-        return '' if not titles else re_tags.sub('', titles[0])
+        if remove_del_text:
+            return '' if not titles else re.sub(r'\s+', ' ', re_tags.sub('', re.sub(r'<del>.*</del>', '', titles[0])))
+        else:
+            return '' if not titles else re_tags.sub('', titles[0])
 
     def clean_length(self, text: str) -> int:
         # TODO: make it word count instead of character count.

--- a/recipe.py
+++ b/recipe.py
@@ -65,9 +65,12 @@ class Recipe:
         text = re.sub(r'\s+', ' ', text.replace('\n', ' '))
 
         titles = re_head.search(text)
-        title = titles[0]
-        title = re.sub(r'<del>.*</del>', '', title)
-        return '' if not titles else re.sub(r'\s+', ' ', re_tags.sub('', title))
+        if not titles:
+            return ''
+        else:
+            title = titles[0]
+            title = re.sub(r'<del>.*</del>', '', title)
+            return re.sub(r'\s+', ' ', re_tags.sub('', title))
 
     def clean_length(self, text: str) -> int:
         # TODO: make it word count instead of character count.

--- a/recipe.py
+++ b/recipe.py
@@ -65,7 +65,9 @@ class Recipe:
         text = re.sub(r'\s+', ' ', text.replace('\n', ' '))
 
         titles = re_head.search(text)
-        return '' if not titles else re_tags.sub('', titles[0])
+        title = titles[0]
+        title = re.sub(r'<del>.*</del>', '', title)
+        return '' if not titles else re.sub(r'\s+', ' ', re_tags.sub('', title))
 
     def clean_length(self, text: str) -> int:
         # TODO: make it word count instead of character count.


### PR DESCRIPTION
See [issue #1873](https://github.com/cu-mkp/m-k-manuscript-data/issues/1873).

Slight modification to `recipe.py` to remove text inside \<del> tags before returning the titles.
I also stripped any additional whitespace that may be leftover, e.g., if we originally had <pre>`my <del>deleted</del> tag`</pre> then it would become <pre> `my  tag` </pre> notably with two spaces instead the single space we might expect. By stripping extra whitespace, we get `my tag` (with a single space) as desired.
I tested the effect by running `update.py` and checking the output of `entry-metadata.csv`.

**Note:** If the Recipe object titles are used anywhere else, these places will also lose their \<del> tagged text. Please confirm that this is acceptable before I merge the PR.