### PR TITLE
Use BeautifulSoup lxml parser to solve issue #1683

### DIFF
--- a/manuscript_helpers.py
+++ b/manuscript_helpers.py
@@ -4,6 +4,7 @@ import pandas as pd
 from collections import OrderedDict
 from typing import List, Union, Optional, Dict
 from recipe import Recipe
+from bs4 import BeautifulSoup
 
 properties = ['animal', 'body_part', 'currency', 'definition',
               'environment', 'material', 'medical', 'measurement',
@@ -71,21 +72,21 @@ def process_file(filepath: str) -> Dict[str, str]:
   # read file, extract text and folio ID
   with open(filepath, encoding="utf-8", errors="surrogateescape") as f:
     text = f.read()
-    folio = filepath.split('/')[-1].split('_')[1][1:] # .../tl_p162v_preTEI.xml -> 162v
+    soup = BeautifulSoup(text, 'lxml')
 
-    text = text.replace('\n', '**NEWLINE**') # re.findall cannot scan over newlines. 
-    divs = re.findall(r'(<div([\w\s=";-]*)>(.*?)</div>)', text) # separate text by divs
-    if divs:
-      for i, div in enumerate(divs): # iterate through divs
-        attributes = div[1] # text within div tag, between second parentheses in the regex.
-        identity = re.findall(r'id="p([\w_]*)"', attributes) # find identity
-        identity = identity[0] if identity else '' # unpack identity from regex
-        key = f'{folio};{identity}' # create unique key for attaching 'continued' entries.
-        if key in entries.keys(): # if this div is a part of another entry, attach them
-          new_text = div[0].replace('**NEWLINE**', '\n').replace('\n\n\n', '\n\n')
-          entries[key] = entries[key] + "\n\n" + new_text
-        else: # otherwise create a new entry in the entries dict.
-          entries[key] = div[0].replace('**NEWLINE**', '\n').replace('\n\n\n', '\n\n')
+    folio = os.path.basename(filepath).split("_")[1][1:] # .../tl_p162v_preTEI.xml -> 162v
+
+    # text = text.replace('\n', '**NEWLINE**') # re.findall cannot scan over newlines. 
+    # divs = re.findall(r'(<div([\w\s=";-]*)>(.*?)</div>)', text) # separate text by divs
+    divs = soup.find_all('div')
+    for div in divs: # iterate through divs
+      identity = div.get("id") # find identity
+      identity = identity if identity else "" # default to empty string if no identity found
+      key = folio + ";" + identity # create unique key for attaching 'continued' entries.
+      if key in entries.keys(): # if this div is a part of another entry, attach them
+        entries[key] += "\n\n" + div.prettify()
+      else: # otherwise create a new entry in the entries dict.
+        entries[key] = div.prettify()
   return entries
 
 def generate_complete_manuscript(apply_corrections=True) -> Dict[str, Recipe]:

--- a/recipe.py
+++ b/recipe.py
@@ -191,11 +191,13 @@ class Recipe:
         if xml:
             return self.versions[version]
 
-        text = self.versions[version].replace('\n', '**NEWLINE**')
-        text = re_tags.sub('', text).replace('**NEWLINE**', '\n')
-        text = re.sub(r'\n+', '\n\n', text)
+        # text = self.versions[version].replace('\n', '**NEWLINE**')
+        # text = re_tags.sub('', text).replace('**NEWLINE**', '\n')
+        # text = re.sub(r'\n+', '\n\n', text)
 
-        return text.strip(' \n')
+        # return text.strip(' \n')
+        soup = BeautifulSoup(self.versions[version], "lxml")
+        return soup.text
 
     def context(self, term: str, version: str) -> str:
         """ Returns five words on either side of the given term in the specified version. """


### PR DESCRIPTION
Instead of using regex replacements to read files and convert them to txt, I have updated recipe.py and manuscript_helpers.py to use BeautifulSoup with an lxml parser. This parser is XML-aware and has powerful capabilities for processing XML and managing encodings. With this library, it is trivial to solve cu-mkp/m-k-manuscript-data#1683 because HTML entities will automatically be converted to unicode, like `&amp;` -> `&`.

This change will indubitably have other effects, but I think they will on the whole be good effects. I cannot predict everything that will change, though, when it comes to derivative files.
While I haven't implemented it yet, this change will also make it easy to do cu-mkp/m-k-manuscript-data#1613, because I can simply add a specific action upon encountering a `<del>` tag.

I recommend at some point we move from BeautifulSoup to a more lightweight XML parser like [lxml](https://lxml.de/), since we do not need all of the features of BeautifulSoup and it is slower.

Fixes cu-mkp/m-k-manuscript-data#1683.