### PR TITLE
Add JSON save/load feature for manuscript generation

### DIFF
--- a/digital_manuscript.py
+++ b/digital_manuscript.py
@@ -10,7 +10,7 @@ properties = ['animal', 'body_part', 'currency', 'definition', 'environment', 'm
 
 class BnF():
 
-  def __init__(self, entry_list: List[str] = [], apply_corrections: bool = True) -> None:
+  def __init__(self, entry_list: List[str] = [], load_json: bool = False, apply_corrections: bool = True) -> None:
     """
     Initialize entire manuscript as a dictionary of Recipe objected keyed by div ID.
     If a list of IDs is given, return a dict with these entries only.
@@ -23,7 +23,7 @@ class BnF():
     Outputs:
       None
     """
-    complete_manuscript = generate_complete_manuscript(apply_corrections=apply_corrections)
+    complete_manuscript = generate_complete_manuscript(load_json=load_json, apply_corrections=apply_corrections)
     if entry_list: # choose specified entries
       self.entries = {i:e for i, e in complete_manuscript.items() if e.identity in entry_list}
     else: # otherwise, return all entries

--- a/manuscript_helpers.py
+++ b/manuscript_helpers.py
@@ -4,6 +4,7 @@ import pandas as pd
 from collections import OrderedDict
 from typing import List, Union, Optional, Dict
 from recipe import Recipe
+import json
 
 properties = ['animal', 'body_part', 'currency', 'definition',
               'environment', 'material', 'medical', 'measurement',
@@ -88,7 +89,7 @@ def process_file(filepath: str) -> Dict[str, str]:
           entries[key] = div[0].replace('**NEWLINE**', '\n').replace('\n\n\n', '\n\n')
   return entries
 
-def generate_complete_manuscript(apply_corrections=True) -> Dict[str, Recipe]:
+def generate_complete_manuscript(load_json=False, apply_corrections=True) -> Dict[str, Recipe]:
   """
   Generate complete manuscript by extracting the text from each folder in /m-k-manuscript-data/ms-xml/
   Apply corrections if specified.
@@ -108,6 +109,15 @@ def generate_complete_manuscript(apply_corrections=True) -> Dict[str, Recipe]:
 
   TODO: Instead of going version by version, consider going folio by folio. 
   """
+  if load_json:
+    f = open("digital_manuscript.json", mode="r")
+    manuscript_dict = json.load(f)
+    f.close()
+    for identity, entry in manuscript_dict["entries"].items():
+      entries[identity] = Recipe(entry["id"], entry["folio"], entry["versions"]["tc"], entry["versions"]["tcn"], entry["versions"]["tl"], json_dict=entry)
+      print("Generating Recipe object from JSON for entry with ID", entry["id"])
+    return entries
+  
   for version in versions: 
     dir_path = f'{manuscript_data_path}/ms-xml/{version}/'
     entry_dict = OrderedDict()

--- a/recipe.py
+++ b/recipe.py
@@ -17,17 +17,29 @@ prop_dict_reverse = {v: k for k, v in prop_dict.items()}
 
 class Recipe:
 
-    def __init__(self, identity: str, folio: str, tc: str, tcn: str, tl: str) -> None:
+    def __init__(self, identity: str, folio: str, tc: str, tcn: str, tl: str, json_dict = None) -> None:
         
-        self.identity: str = identity # id of the entry
-        self.folio: str = folio # folio of the entry
-        self.versions: Dict[str, str] = {'tc': tc, 'tcn': tcn, 'tl': tl} # dict that contains xml text
-        self.title = {k: self.find_title(v) for k, v in self.versions.items()}
-        self.categories: List[str] = self.find_categories(self.text('tl', xml=True))
-        self.length = {k: self.clean_length(v) for k, v in self.versions.items()}
+        if json_dict:
+            self.identity = json_dict["id"] # id of the entry
+            self.folio = json_dict["folio"] # folio of the entry
+            self.versions = json_dict["versions"] # dict that contains xml text
+            self.title = json_dict["title"]
+            self.categories = json_dict["categories"]
+            self.length = json_dict["length"]
 
-        self.properties: Dict[str, Dict[str, List[str]]] # {prop_type: {version: [prop1, prop2, ...]}}
-        self.properties = self.find_all_properties()
+            self.properties: Dict[str, Dict[str, List[str]]] # {prop_type: {version: [prop1, prop2, ...]}}
+            self.properties = json_dict["properties"]
+
+        else:
+            self.identity: str = identity # id of the entry
+            self.folio: str = folio # folio of the entry
+            self.versions: Dict[str, str] = {'tc': tc, 'tcn': tcn, 'tl': tl} # dict that contains xml text
+            self.title = {k: self.find_title(v) for k, v in self.versions.items()}
+            self.categories: List[str] = self.find_categories(self.text('tl', xml=True))
+            self.length = {k: self.clean_length(v) for k, v in self.versions.items()}
+
+            self.properties: Dict[str, Dict[str, List[str]]] # {prop_type: {version: [prop1, prop2, ...]}}
+            self.properties = self.find_all_properties()
 
         self.margins = self.find_margins()
         self.del_tags = self.find_del()

--- a/update.py
+++ b/update.py
@@ -224,8 +224,9 @@ def make_json(manuscript: BnF):
     }
   '''
   manuscript_dict = {}
+  manuscript_dict["entries"] = {}
   for identity, entry in manuscript.entries.items():
-    manuscript_dict[identity] = {
+    manuscript_dict["entries"][identity] = {
       "id" : entry.identity,
       "folio" : entry.folio,
       "versions" : entry.versions,
@@ -247,7 +248,7 @@ def save_as_json(manuscript: BnF, outfile) -> None:
 
 def update():
 
-  manuscript = BnF(apply_corrections=False)
+  manuscript = BnF(load_json=True, apply_corrections=False)
 
   print('Updating metadata')
   update_metadata(manuscript)
@@ -261,8 +262,8 @@ def update():
   print('Updating allFolios')
   update_all_folios(manuscript)
 
-  print("Saving to JSON")
-  save_as_json(manuscript, "digital_manuscript.json")
+  # print("Saving to JSON")
+  # save_as_json(manuscript, "digital_manuscript.json")
 
   update_time()
 

--- a/update.py
+++ b/update.py
@@ -248,7 +248,7 @@ def save_as_json(manuscript: BnF, outfile) -> None:
 
 def update():
 
-  manuscript = BnF(load_json=True, apply_corrections=False)
+  manuscript = BnF(load_json=False, apply_corrections=False)
 
   print('Updating metadata')
   update_metadata(manuscript)

--- a/update.py
+++ b/update.py
@@ -3,7 +3,8 @@
 import os
 import sys
 import re
-from typing import List
+from typing import List, Dict
+import json
 
 # Third Party Modules
 import pandas as pd
@@ -176,6 +177,74 @@ def update_time():
   f.write('\n'.join(lines))
   f.close
 
+def make_json(manuscript: BnF):
+  '''
+  Make the manuscript into a JSON-friendly dictionary with the following format:
+    {
+      "entries" : {
+        "127v_2" : {
+          "id" : "127v_2",
+          "folio" : "127v",
+          "versions" : {
+            "tc" : THE_ENTIRE_RAW_TC_XML,
+            "tcn" : THE_ENTIRE_RAW_TCN_XML,
+            "tl" : THE_ENTIRE_RAW_TL_XML
+          },
+          "title" : {
+            "tc" : TC_TITLE,
+            "tcn" : TCN_TITLE,
+            "tl" : TL_TITLE,
+          },
+          "categories" : [
+            CATEGORY_1,
+            CATEGORY_2,
+            ...
+          ],
+          "length" : {
+            "tc" : LENGTH_TC,
+            "tcn" : LENGTH_TCN,
+            "tl" : LENGTH_TL
+          },
+          "properties" : {
+            "animal" : {
+              "tc" : [TERM_1, %TERM_2, ...],
+              "tcn" : [TERM_1, %TERM_2, ...],
+              "tl" : [TERM_1, %TERM_2, ...]
+            },
+            ... more properties
+          }
+          // pretty sure we're gonna skip margins, del_tags, and captions
+          // and we can just recompute those from XML upon loading JSON
+        },
+        "127v_3" : {
+          ...
+        },
+        ... more entries
+      }
+    }
+  '''
+  manuscript_dict = {}
+  for identity, entry in manuscript.entries.items():
+    manuscript_dict[identity] = {
+      "id" : entry.identity,
+      "folio" : entry.folio,
+      "versions" : entry.versions,
+      "title" : entry.title,
+      "categories" : entry.categories,
+      "length" : entry.length,
+      "properties" : entry.properties,
+    }
+  return manuscript_dict
+
+def save_as_json(manuscript: BnF, outfile) -> None:
+  '''
+  Save the manuscript in JSON format to a specified .json file.
+  '''
+  manuscript_dict = make_json(manuscript)
+  f = open(outfile, mode="w")
+  json.dump(manuscript_dict, f, indent=4)
+  f.close()
+
 def update():
 
   manuscript = BnF(apply_corrections=False)
@@ -191,6 +260,9 @@ def update():
 
   print('Updating allFolios')
   update_all_folios(manuscript)
+
+  print("Saving to JSON")
+  save_as_json(manuscript, "digital_manuscript.json")
 
   update_time()
 


### PR DESCRIPTION
Fixes #25.
From my comment in that issue:
> I used the standard Python JSON library to add an optional JSON save/load feature for the manuscript object. In update.py, you can tell it to save the manuscript object to a JSON (about 8 MB) which contains most of the information in each Recipe object. Then, next time you run update.py, you can tell it to load that JSON file, which speeds up generating the Recipe objects (the longest part of the generation process) from several minutes to a fraction of a second.
> 
> Clearly, the bottleneck in update.py was those few methods in the Recipe object: find_title(), find_categories(), clean_length(), and find_all_properties(). By storing the output of those computations in a JSON, any work to do with update.py that does not require regenerating the manuscript from original files (i.e. work to do with derivative files rather than original files) will be much more pleasant.