### PR TITLE
issue63: add <fr> tag to entry-metadata.csv + bug fixes

### DIFF
--- a/manuscript.py
+++ b/manuscript.py
@@ -25,6 +25,10 @@ def clean_folio(folio: str) -> str:
 def clean_id(identity: str) -> str:
     return identity.lstrip("p").lstrip("0").replace("_","")
 
+def display_id(identity: str) -> str:
+    # inverse of clean_id()
+    return "p" + identity[:-1].zfill(4) + "_" + identity[-1]
+
 def separate_by_id(filepath: str) -> Dict[str, et.Element]:
     """Take a file path, read it as XML, and process it into separate elements by ID.
     Returned object is a dictionary of lxml.etree.Element objects keyed by entry ID as a string.
@@ -219,8 +223,9 @@ class Manuscript():
             os.makedirs(xml_path, exist_ok=True)
 
             for identity, entry in entries.items():
-                filepath_txt = os.path.join(txt_path, f'{version}_{entry.identity}.txt')
-                filepath_xml = os.path.join(xml_path, f'{version}_{entry.identity}.xml')
+                # need to leftpad this
+                filepath_txt = os.path.join(txt_path, f'{version}_{display_id(entry.identity)}.txt')
+                filepath_xml = os.path.join(xml_path, f'{version}_{display_id(entry.identity)}.xml')
 
                 content_txt = entry.text
                 content_xml = entry.xml_string # should already have an <entry> root tag :)

--- a/update.py
+++ b/update.py
@@ -1,4 +1,4 @@
-# Last Updated | 2020-11-14
+# Last Updated | 2021-01-25
 # Python Modules
 import os
 import sys

--- a/utils.py
+++ b/utils.py
@@ -33,6 +33,7 @@ prop_dict = {
     'greek': 'el',
     'italian': 'it',
     'latin': 'la',
+    'french': 'fr',
     'occitan': 'oc',
     'poitevin': 'po'
 }


### PR DESCRIPTION
Firstly a bug fix. Filenames in `entries/` derivatives were not being formatted properly.
Correct: `tl_p015r_1.txt`
What we have: `tl_15r1.txt`
This was caused by the `clean_id()` function in `manuscript.py`, which makes it easier to work with the entry IDs in Python, but I forgot to reverse this change before writing the derivative. Should be fixed now.
*Run `update.py` to test this.*

And now for the actual issue: add `<fr>` tag to `utils.py` property dictionary, which should seamlessly add the property to the `entry-metadata.csv` derivative without affecting anything else.
Again, *run `update.py` to test this*.